### PR TITLE
Bugfix/file upload

### DIFF
--- a/src/Controller/Backend/FileController.php
+++ b/src/Controller/Backend/FileController.php
@@ -13,6 +13,7 @@ use OHMedia\FileBundle\Repository\FileRepository;
 use OHMedia\FileBundle\Security\Voter\FileVoter;
 use OHMedia\FileBundle\Service\FileBrowser;
 use OHMedia\FileBundle\Util\FileUtil;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,7 +63,7 @@ class FileController extends AbstractController
     #[Route('/folder/{id}/file/create', name: 'file_create_with_folder', methods: ['GET', 'POST'])]
     public function fileCreateWithFolder(
         Request $request,
-        FileFolder $folder
+        #[MapEntity(id: 'id')] FileFolder $folder,
     ): Response {
         $file = (new File())->setBrowser(true);
 
@@ -82,7 +83,7 @@ class FileController extends AbstractController
     #[Route('/folder/{id}/image/create', name: 'image_create_with_folder', methods: ['GET', 'POST'])]
     public function imageCreateWithFolder(
         Request $request,
-        FileFolder $folder
+        #[MapEntity(id: 'id')] FileFolder $folder,
     ): Response {
         $file = (new File())->setBrowser(true)->setImage(true);
 
@@ -152,7 +153,7 @@ class FileController extends AbstractController
     #[Route('/file/{id}/edit', name: 'file_edit', methods: ['GET', 'POST'])]
     public function edit(
         Request $request,
-        File $file
+        #[MapEntity(id: 'id')] File $file,
     ): Response {
         $this->denyAccessUnlessGranted(
             FileVoter::EDIT,
@@ -193,7 +194,7 @@ class FileController extends AbstractController
     #[Route('/file/{id}/move', name: 'file_move', methods: ['GET', 'POST'])]
     public function move(
         Request $request,
-        File $file,
+        #[MapEntity(id: 'id')] File $file,
     ): Response {
         $noun = $file->isImage() ? 'image' : 'file';
 
@@ -236,7 +237,7 @@ class FileController extends AbstractController
     #[Route('/file/{id}/lock', name: 'file_lock', methods: ['POST'])]
     public function lock(
         Request $request,
-        File $file,
+        #[MapEntity(id: 'id')] File $file,
     ): Response {
         $noun = $file->isImage() ? 'image' : 'file';
 
@@ -263,7 +264,7 @@ class FileController extends AbstractController
     #[Route('/file/{id}/unlock', name: 'file_unlock', methods: ['POST'])]
     public function unlock(
         Request $request,
-        File $file,
+        #[MapEntity(id: 'id')] File $file,
     ): Response {
         $noun = $file->isImage() ? 'image' : 'file';
 
@@ -301,7 +302,7 @@ class FileController extends AbstractController
     #[Route('/file/{id}/delete', name: 'file_delete', methods: ['POST'])]
     public function delete(
         Request $request,
-        File $file,
+        #[MapEntity(id: 'id')] File $file,
     ): Response {
         $noun = $file->isImage() ? 'image' : 'file';
 

--- a/src/Controller/Backend/FileFolderController.php
+++ b/src/Controller/Backend/FileFolderController.php
@@ -12,6 +12,7 @@ use OHMedia\FileBundle\Form\Type\FileFolderMoveType;
 use OHMedia\FileBundle\Repository\FileFolderRepository;
 use OHMedia\FileBundle\Security\Voter\FileFolderVoter;
 use OHMedia\FileBundle\Service\FileBrowser;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
@@ -39,7 +40,7 @@ class FileFolderController extends AbstractController
     #[Route('/folder/{id}/folder/create', name: 'file_folder_create_with_folder', methods: ['GET', 'POST'])]
     public function createWithFolder(
         Request $request,
-        FileFolder $parent
+        #[MapEntity(id: 'id')] FileFolder $parent,
     ): Response {
         $folder = (new FileFolder())->setBrowser(true);
 
@@ -89,8 +90,10 @@ class FileFolderController extends AbstractController
     }
 
     #[Route('/folder/{id}', name: 'file_folder_view', methods: ['GET'])]
-    public function view(FileFolder $folder, FileBrowser $fileBrowser): Response
-    {
+    public function view(
+        #[MapEntity(id: 'id')] FileFolder $folder,
+        FileBrowser $fileBrowser,
+    ): Response {
         $this->denyAccessUnlessGranted(
             FileFolderVoter::VIEW,
             $folder,
@@ -119,7 +122,7 @@ class FileFolderController extends AbstractController
     #[Route('/folder/{id}/edit', name: 'file_folder_edit', methods: ['GET', 'POST'])]
     public function edit(
         Request $request,
-        FileFolder $folder,
+        #[MapEntity(id: 'id')] FileFolder $folder,
     ): Response {
         $this->denyAccessUnlessGranted(
             FileFolderVoter::EDIT,
@@ -160,7 +163,7 @@ class FileFolderController extends AbstractController
     #[Route('/folder/{id}/move', name: 'file_folder_move', methods: ['GET', 'POST'])]
     public function move(
         Request $request,
-        FileFolder $folder,
+        #[MapEntity(id: 'id')] FileFolder $folder,
     ): Response {
         $this->denyAccessUnlessGranted(
             FileFolderVoter::MOVE,
@@ -201,7 +204,7 @@ class FileFolderController extends AbstractController
     #[Route('/folder/{id}/lock', name: 'file_folder_lock', methods: ['POST'])]
     public function lock(
         Request $request,
-        FileFolder $folder,
+        #[MapEntity(id: 'id')] FileFolder $folder,
     ): Response {
         $this->denyAccessUnlessGranted(
             FileFolderVoter::LOCK,
@@ -226,7 +229,7 @@ class FileFolderController extends AbstractController
     #[Route('/folder/{id}/unlock', name: 'file_folder_unlock', methods: ['POST'])]
     public function unlock(
         Request $request,
-        FileFolder $folder,
+        #[MapEntity(id: 'id')] FileFolder $folder,
     ): Response {
         $this->denyAccessUnlessGranted(
             FileFolderVoter::UNLOCK,
@@ -258,7 +261,7 @@ class FileFolderController extends AbstractController
     #[Route('/folder/{id}/delete', name: 'file_folder_delete', methods: ['POST'])]
     public function delete(
         Request $request,
-        FileFolder $folder,
+        #[MapEntity(id: 'id')] FileFolder $folder,
     ): Response {
         $this->denyAccessUnlessGranted(
             FileFolderVoter::DELETE,

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -344,7 +344,7 @@ class File
     private ?HttpFile $file = null;
     private ?string $oldPath = null;
 
-    public function setFile(HttpFile $file = null): self
+    public function setFile(?HttpFile $file = null): self
     {
         $this->file = $file;
 
@@ -358,6 +358,15 @@ class File
         } else {
             // set it to something not null
             $this->path = self::PATH_INITIAL;
+        }
+
+        // For the case when the File entity is cloned
+        // but a new $file is set before saving.
+        // $oldPath will be pointing to the cloned file
+        // which should not get removed!
+        if ($this->cloned) {
+            $this->cloned = false;
+            $this->oldPath = null;
         }
 
         return $this;

--- a/src/Form/Type/FileEntityType.php
+++ b/src/Form/Type/FileEntityType.php
@@ -173,7 +173,7 @@ class FileEntityType extends AbstractType
         $form = $event->getForm();
 
         if ($this->fileToRemove) {
-            $this->fileRepository->remove($this->fileToRemove, true);
+            $this->fileRepository->remove($this->fileToRemove, false);
 
             return;
         }
@@ -188,7 +188,7 @@ class FileEntityType extends AbstractType
             $resizes = $file->getResizes();
 
             foreach ($resizes as $resize) {
-                $this->fileRepository->remove($resize, true);
+                $this->fileRepository->remove($resize, false);
             }
         }
     }

--- a/src/Service/FileLifecycle.php
+++ b/src/Service/FileLifecycle.php
@@ -14,7 +14,7 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 
 class FileLifecycle
 {
-    private FileSystem $fileSystem;
+    private Filesystem $fileSystem;
     private AsciiSlugger $slugger;
 
     public function __construct(
@@ -22,7 +22,7 @@ class FileLifecycle
         private FileRepository $fileRepository,
         private FileManager $fileManager
     ) {
-        $this->fileSystem = new FileSystem();
+        $this->fileSystem = new Filesystem();
         $this->slugger = new AsciiSlugger();
     }
 
@@ -73,6 +73,10 @@ class FileLifecycle
 
     public function postRemove(FileEntity $file)
     {
+        if ($file->isCloned()) {
+            return;
+        }
+
         $this->removeFilepath($file->getPath());
     }
 


### PR DESCRIPTION
Issues with potential race conditions where the FileEntityType class was flushing the entity manager. These calls have been set to not flush.

Found another issue where if you clone a File entity, then change the uploaded file in the subsequent form, the original would get deleted and the new file would be missing information. You can see this with a simple page template that has an upload field. Edit the content of a Live/Published page with an image, then replace that image. You will see the old image is gone and the new image is broken. If you update the Draft image, it will work.