### PR TITLE
__clone Hydration

### DIFF
--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Persistence\Proxy;
 use OHMedia\FileBundle\Repository\FileRepository;
 use OHMedia\UtilityBundle\Entity\BlameableEntityTrait;
 use Symfony\Component\HttpFoundation\File\File as HttpFile;
@@ -84,13 +85,20 @@ class File
 
     public function __clone()
     {
-        $this->id = null;
-        $this->cloned = true;
-        // don't want cloned items to appear in the File browser
-        $this->browser = false;
-        $this->folder = null;
+        if ($this->id) {
+            if ($this instanceof Proxy && !$this->__isInitialized()) {
+                // Initialize the proxy to load all properties
+                $this->__load();
+            }
 
-        $this->resizes = new ArrayCollection();
+            $this->id = null;
+            $this->cloned = true;
+            // don't want cloned items to appear in the File browser
+            $this->browser = false;
+            $this->folder = null;
+
+            $this->resizes = new ArrayCollection();
+        }
     }
 
     public function isCloned(): bool


### PR DESCRIPTION
https://github.com/ohmediaorg/file-bundle/issues/12


I have not found any issue with this approach. The only alternative I can think of is to explicitly hydrate the required params in the __clone functions. Though that would be more to maintain down the line, more prone to bugs I think.

Within the Symfony codebase, there is the pattern of checking for the Proxy instance + checking if it's hydrated before running load

example from the EntityUserProvider
```
        if ($refreshedUser instanceof Proxy && !$refreshedUser->__isInitialized()) {
            $refreshedUser->__load();
        }
```

We could instead do this check from the PageContentImage and load from there. Though I think it makes more sense in this context to check itself within its own clone function, it encapsulation the clone functionality within itself.




Then I think we probably want to update all of our clone functions with the pattern

```
//following the doctrine documentation for safely using __clone()
if($this->id)
{
  //since we're deleting the ID, we need to make sure its hydrated.
  if ($this instanceof Proxy && !$this->__isInitialized()) {
        // Initialize the proxy to load all properties
        $this->__load();
    }
    
    $this->id = null;
    
    Do your custom stuff ...
}
```